### PR TITLE
Fix a warning of PHP 8.1 while listing blobs

### DIFF
--- a/src/Blob/BlobRestProxy.php
+++ b/src/Blob/BlobRestProxy.php
@@ -1496,11 +1496,13 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
             Resources::QP_COMP,
             'list'
         );
-        $this->addOptionalQueryParam(
-            $queryParams,
-            Resources::QP_PREFIX_LOWERCASE,
-            str_replace('\\', '/', $options->getPrefix())
-        );
+        if (null !== $options->getPrefix()) {
+            $this->addOptionalQueryParam(
+                $queryParams,
+                Resources::QP_PREFIX_LOWERCASE,
+                str_replace('\\', '/', $options->getPrefix())
+            );
+        }
         $this->addOptionalQueryParam(
             $queryParams,
             Resources::QP_MARKER_LOWERCASE,


### PR DESCRIPTION
Related to:
https://github.com/Azure/azure-storage-php/pull/340