### PR TITLE
Fixed unit tests errors

### DIFF
--- a/src/Blob/Models/SetBlobPropertiesResult.php
+++ b/src/Blob/Models/SetBlobPropertiesResult.php
@@ -33,7 +33,7 @@ class SetBlobPropertiesResult
             Resources::ETAG,
             $headers
         ));
-        $result->setSequenceNumber(Utilities::tryGetValueInsensitive(
+        $result->setSequenceNumber((int) Utilities::tryGetValueInsensitive(
             Resources::X_MS_BLOB_SEQUENCE_NUMBER,
             $headers
         ));

--- a/src/Common/Internal/Validate.php
+++ b/src/Common/Internal/Validate.php
@@ -47,9 +47,7 @@ class Validate
      */
     public static function isBoolean($var)
     {
-        if (!is_bool($var)) {
-            throw new InvalidArgumentTypeException(gettype(true));
-        }
+        (bool) $var;
     }
 
     /**

--- a/src/Common/Internal/Validate.php
+++ b/src/Common/Internal/Validate.php
@@ -33,7 +33,7 @@ class Validate
     {
         try {
             (string) $var;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             throw new InvalidArgumentTypeException(gettype(''), $name);
         }
     }
@@ -47,7 +47,9 @@ class Validate
      */
     public static function isBoolean($var)
     {
-        (bool) $var;
+        if (!is_bool($var)) {
+            throw new InvalidArgumentTypeException(gettype(true));
+        }
     }
 
     /**
@@ -92,9 +94,7 @@ class Validate
      */
     public static function isInteger($var, $name)
     {
-        try {
-            (int) $var;
-        } catch (\Exception $e) {
+        if (!is_int($var)) {
             throw new InvalidArgumentTypeException(gettype(123), $name);
         }
     }
@@ -110,7 +110,7 @@ class Validate
     {
         try {
             (string) $var;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return false;
         }
 

--- a/src/Common/Middlewares/RetryMiddlewareFactory.php
+++ b/src/Common/Middlewares/RetryMiddlewareFactory.php
@@ -134,10 +134,10 @@ class RetryMiddlewareFactory
 
             if (!$response) {
                 if (!$exception || !($exception instanceof RequestException)) {
+                    if ($exception instanceof ConnectException) {
+                        return $retryConnect;
+                    }
                     return false;
-                }
-                if ($exception instanceof ConnectException) {
-                    return $retryConnect;
                 }
                 $response = $exception->getResponse();
                 if (!$response) {

--- a/src/Common/Models/ServiceProperties.php
+++ b/src/Common/Models/ServiceProperties.php
@@ -38,7 +38,9 @@ class ServiceProperties
         if (array_key_exists(Resources::XTAG_LOGGING, $parsedResponse)) {
             $result->setLogging(Logging::create($parsedResponse[Resources::XTAG_LOGGING]));
         }
-        $result->setHourMetrics(Metrics::create($parsedResponse[Resources::XTAG_HOUR_METRICS]));
+        if (array_key_exists(Resources::XTAG_HOUR_METRICS, $parsedResponse)) {
+            $result->setHourMetrics(Metrics::create($parsedResponse[Resources::XTAG_HOUR_METRICS]));
+        }
         if (array_key_exists(Resources::XTAG_MINUTE_METRICS, $parsedResponse)) {
             $result->setMinuteMetrics(Metrics::create($parsedResponse[Resources::XTAG_MINUTE_METRICS]));
         }

--- a/src/File/Models/FileProperties.php
+++ b/src/File/Models/FileProperties.php
@@ -48,7 +48,7 @@ class FileProperties
         );
 
         $result->setContentLength(
-            Utilities::tryGetValue($parsed, Resources::CONTENT_LENGTH)
+            (int) Utilities::tryGetValue($parsed, Resources::CONTENT_LENGTH)
         );
 
         $result->setContentType(

--- a/src/File/Models/FileProperties.php
+++ b/src/File/Models/FileProperties.php
@@ -437,11 +437,10 @@ class FileProperties
     /**
      * Sets file copySource.
      *
-     * @param int $copySource value.
+     * @param string $copySource value.
      */
     protected function setCopySource($copySource)
     {
-        Validate::isInteger($copySource, 'copySource');
         $this->copySource = $copySource;
     }
 

--- a/tests/Framework/RestProxyTestBase.php
+++ b/tests/Framework/RestProxyTestBase.php
@@ -47,6 +47,9 @@ class RestProxyTestBase extends \PHPUnit\Framework\TestCase
 
     public function __construct()
     {
+        if (method_exists(get_parent_class(), '__construct')) {
+            parent::__construct(...func_get_args());
+        }
         $this->xmlSerializer = new XmlSerializer();
         Logger::setLogFile('C:\log.txt');
 

--- a/tests/Framework/SASFunctionalTestBase.php
+++ b/tests/Framework/SASFunctionalTestBase.php
@@ -49,6 +49,9 @@ class SASFunctionalTestBase extends \PHPUnit\Framework\TestCase
 
     public function __construct()
     {
+        if (method_exists(get_parent_class(), '__construct')) {
+            parent::__construct(...func_get_args());
+        }
         $this->xmlSerializer = new XmlSerializer();
         $this->connectionString = TestResources::getWindowsAzureStorageServicesConnectionString();
         $this->serviceSettings =

--- a/tests/Framework/SASFunctionalTestBase.php
+++ b/tests/Framework/SASFunctionalTestBase.php
@@ -301,6 +301,6 @@ class SASFunctionalTestBase extends \PHPUnit\Framework\TestCase
         } catch (ServiceException $e) {
             $message = $e->getMessage();
         }
-        self::assertContains($errorMsg, $message, $failureMessage);
+        self::assertStringContainsString($errorMsg, $message, $failureMessage);
     }
 }

--- a/tests/Framework/TestResources.php
+++ b/tests/Framework/TestResources.php
@@ -1715,7 +1715,7 @@ DataServiceVersion: 1.0;
 
     public static function getTableSampleBody()
     {
-        return '<?xml version="1.0" encoding="utf-8"?><entry xml:base="https://phput.table.core.windows.net/" xmlns="http://www.w3.org/2005/Atom" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"><id>https://phput.table.core.windows.net/Tables(\'gettable\')</id><category term="phput.Tables" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" /><link rel="edit" title="Tables" href="Tables(\'gettable\')" /><title /><updated>2017-02-16T03:48:16Z</updated><author><name /></author><content type="application/xml"><m:properties><d:TableName>gettable</d:TableName></m:properties></content></entry>';
+        return '{"TableName": "gettable"}';
     }
 
     public static function getInsertEntitySampleBody()

--- a/tests/Functional/Blob/BlobServiceFunctionalTest.php
+++ b/tests/Functional/Blob/BlobServiceFunctionalTest.php
@@ -2630,7 +2630,7 @@ class BlobServiceFunctionalTest extends FunctionalTestBase
             $message = $e->getMessage();
         }
         self::assertEquals(TestResources::STATUS_CONFLICT, $code);
-        self::assertContains('The specified blob already exists', $message);
+        self::assertStringContainsString('The specified blob already exists', $message);
         unlink($path);
     }
 
@@ -2865,8 +2865,8 @@ class BlobServiceFunctionalTest extends FunctionalTestBase
             } catch (ServiceException $e) {
                 $message = $e->getMessage();
             }
-            self::assertContains('400', $message);
-            self::assertContains(
+            self::assertStringContainsString('400', $message);
+            self::assertStringContainsString(
                 'The MD5 value specified in the request did not match with the MD5 value calculated by the server.',
                 $message
             );
@@ -3006,7 +3006,7 @@ class BlobServiceFunctionalTest extends FunctionalTestBase
             if ($errorMsg == '') {
                 self::assertEquals('', $message);
             } else {
-                self::assertContains($errorMsg, $message);
+                self::assertStringContainsString($errorMsg, $message);
             }
         }
     }
@@ -3024,7 +3024,7 @@ class BlobServiceFunctionalTest extends FunctionalTestBase
         } catch (ServiceException $e) {
             $message = $e->getMessage();
         }
-        self::assertContains('There is currently a lease on the container and no lease ID was specified in the request', $message);
+        self::assertStringContainsString('There is currently a lease on the container and no lease ID was specified in the request', $message);
         $options = new BlobServiceOptions();
         $options->setLeaseId($leaseId);
         $this->restProxy->deleteContainer($container, $options);
@@ -3045,7 +3045,7 @@ class BlobServiceFunctionalTest extends FunctionalTestBase
         } catch (ServiceException $e) {
             $message = $e->getMessage();
         }
-        self::assertContains('There is currently a lease on the blob and no lease ID was specified in the request.', $message);
+        self::assertStringContainsString('There is currently a lease on the blob and no lease ID was specified in the request.', $message);
         $options = new DeleteBlobOptions();
         $options->setLeaseId($leaseId);
         $this->restProxy->deleteBlob($container, $blob, $options);
@@ -3067,13 +3067,13 @@ class BlobServiceFunctionalTest extends FunctionalTestBase
         } catch (ServiceException $e) {
             $message = $e->getMessage();
         }
-        self::assertContains(' The value for one of the HTTP headers is not in the correct format.', $message);
+        self::assertStringContainsString(' The value for one of the HTTP headers is not in the correct format.', $message);
         try {
             $this->restProxy->acquireLease($container, $blob, $leaseId, 61);
         } catch (ServiceException $e) {
             $message = $e->getMessage();
         }
-        self::assertContains(' The value for one of the HTTP headers is not in the correct format.', $message);
+        self::assertStringContainsString(' The value for one of the HTTP headers is not in the correct format.', $message);
         $result = $this->restProxy->acquireLease($container, $blob, $leaseId, 15);
         self::assertEquals($leaseId, $result->getLeaseId());
         //test lease duration expire
@@ -3108,7 +3108,7 @@ class BlobServiceFunctionalTest extends FunctionalTestBase
         } catch (ServiceException $e) {
             $message = $e->getMessage();
         }
-        self::assertContains('There is currently a lease on the blob and no lease ID was specified in the request.', $message);
+        self::assertStringContainsString('There is currently a lease on the blob and no lease ID was specified in the request.', $message);
 
         //test release lease
         $this->restProxy->releaseLease($container, $blob, $leaseId);
@@ -3120,7 +3120,7 @@ class BlobServiceFunctionalTest extends FunctionalTestBase
         } catch (ServiceException $e) {
             $message = $e->getMessage();
         }
-        self::assertContains('There is currently a lease on the blob and no lease ID was specified in the request.', $message);
+        self::assertStringContainsString('There is currently a lease on the blob and no lease ID was specified in the request.', $message);
 
         //test break lease
         $result = $this->restProxy->breakLease($container, $blob, 10);
@@ -3130,7 +3130,7 @@ class BlobServiceFunctionalTest extends FunctionalTestBase
         } catch (ServiceException $e) {
             $message = $e->getMessage();
         }
-        self::assertContains('There is already a lease present.', $message);
+        self::assertStringContainsString('There is already a lease present.', $message);
         \sleep(10);
         $this->restProxy->acquireLease($container, $blob, $leaseId);
         $options = new DeleteBlobOptions();

--- a/tests/Functional/File/FileServiceFunctionalTest.php
+++ b/tests/Functional/File/FileServiceFunctionalTest.php
@@ -1668,8 +1668,8 @@ class FileServiceFunctionalTest extends FunctionalTestBase
             } catch (ServiceException $e) {
                 $message = $e->getMessage();
             }
-            self::assertContains('400', $message);
-            self::assertContains(
+            self::assertStringContainsString('400', $message);
+            self::assertStringContainsString(
                 'The MD5 value specified in the request did not match with the MD5 value calculated by the server.',
                 $message
             );
@@ -1756,7 +1756,7 @@ class FileServiceFunctionalTest extends FunctionalTestBase
         if ($error == '') {
             self::assertEquals($error, $message);
         } else {
-            self::assertContains($error, $message);
+            self::assertStringContainsString($error, $message);
         }
     }
 

--- a/tests/Unit/Blob/BlobRestProxyTest.php
+++ b/tests/Unit/Blob/BlobRestProxyTest.php
@@ -1649,7 +1649,7 @@ class BlobRestProxyTest extends BlobServiceRestProxyTestBase
             $this->restProxy->abortCopy($destinationContainerName, $destinationBlobName, $copyId);
         } catch (ServiceException $e) {
             self::assertEquals(409, $e->getCode());
-            self::assertContains('There is currently no pending copy operation.', $e->getErrorText());
+            self::assertStringContainsString('There is currently no pending copy operation.', $e->getErrorText());
         }
     }
 

--- a/tests/Unit/Common/Exceptions/ServiceExceptionTest.php
+++ b/tests/Unit/Common/Exceptions/ServiceExceptionTest.php
@@ -101,7 +101,7 @@ class ServiceExceptionTest extends \PHPUnit\Framework\TestCase
     public function testNoWarningForNonXmlErrorMessage()
     {
         // Warnings are silenced in parseErrorMessage once they are converted to exceptions
-        \PHPUnit\Framework\Error\Warning::$enabled = false;
+        // \PHPUnit\Framework\Error\Warning::$enabled = false;
 
         // Setup
         $response = TestResources::getFailedResponseJson(210, 'test info');

--- a/tests/Unit/Table/TableRestProxyTest.php
+++ b/tests/Unit/Table/TableRestProxyTest.php
@@ -71,7 +71,7 @@ class TableRestProxyTest extends TableServiceRestProxyTestBase
 
         // Setup
         $xml = TestResources::setServicePropertiesSample();
-        $xml['HourMetrics']['RetentionPolicy'] = null;
+        unset($xml['HourMetrics']);
         $expected = ServiceProperties::create($xml);
 
         // Test

--- a/tests/Unit/Table/TableRestProxyTest.php
+++ b/tests/Unit/Table/TableRestProxyTest.php
@@ -70,12 +70,14 @@ class TableRestProxyTest extends TableServiceRestProxyTestBase
         $this->skipIfEmulated();
 
         // Setup
+        $current = $this->restProxy->getServiceProperties();
         $xml = TestResources::setServicePropertiesSample();
         unset($xml['HourMetrics']);
         $expected = ServiceProperties::create($xml);
 
         // Test
         $this->setServiceProperties($expected);
+        $expected->setHourMetrics($current->getValue()->getHourMetrics());
         //Add 30s interval to wait for setting to take effect.
         \sleep(30);
         $actual = $this->restProxy->getServiceProperties();


### PR DESCRIPTION
There are still two issues:

- in two tests Utilities::tryParseAccountNameFromUrl is called with a null url
- tests that relies on TableRestProxy::queryTables failes. This is because the first call returns 0 tables and the continuationToken to use in the next request to get the tables.

```
PHPUnit 9.6.15 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.26
..................................................................................... 255 / 876 ( 29%)
..............................
Deprecated: parse_url(): Passing null to parameter #1 ($url) of type string is deprecated in C:\Users\chack1172\git\azure-storage-php\src\Common\Internal\Utilities.php on line 56

Deprecated: explode(): Passing null to parameter #2 ($string) of type string is deprecated in C:\Users\chack1172\git\azure-storage-php\src\Common\Internal\Utilities.php on line 59
....................................................... 340 / 876 ( 38%)
..................................................................................... 425 / 876 ( 48%)
..................................................................................... 510 / 876 ( 58%)
..................................................................................... 595 / 876 ( 67%)
.........................................................
Deprecated: parse_url(): Passing null to parameter #1 ($url) of type string is deprecated in C:\Users\chack1172\git\azure-storage-php\src\Common\Internal\Utilities.php on line 56

Deprecated: explode(): Passing null to parameter #2 ($string) of type string is deprecated in C:\Users\chack1172\git\azure-storage-php\src\Common\Internal\Utilities.php on line 59
............................ 680 / 876 ( 77%)
..................................................................................... 765 / 876 ( 87%)
............................................................................F..FF.... 850 / 876 ( 97%)
..........................                                                            876 / 876 (100%)

Time: 04:11.412, Memory: 124.00 MB

There were 3 failures:

F:\Users\nereo.berardozzi\git\chack1172\azure-storage-php\tests\Unit\Table\TableRestProxyTest.php:84

1) AzureOSS\Storage\Tests\Unit\Table\TableRestProxyTest::testCreateTable
Failed asserting that actual size 0 matches expected size 1.

C:\Users\chack1172\git\azure-storage-php\tests\Unit\Table\TableRestProxyTest.php:97

2) AzureOSS\Storage\Tests\Unit\Table\TableRestProxyTest::testQueryTablesSimple
Failed asserting that actual size 0 matches expected size 2.

C:\Users\chack1172\git\azure-storage-php\tests\Unit\Table\TableRestProxyTest.php:140

3) AzureOSS\Storage\Tests\Unit\Table\TableRestProxyTest::testQueryTablesOneTable
Failed asserting that actual size 0 matches expected size 1.

C:\Users\chack1172\git\azure-storage-php\tests\Unit\Table\TableRestProxyTest.php:156

FAILURES!
Tests: 876, Assertions: 2157, Failures: 3.
```