### PR TITLE
Allow null for secondaryUri

### DIFF
--- a/src/Common/Internal/ServiceRestProxy.php
+++ b/src/Common/Internal/ServiceRestProxy.php
@@ -29,7 +29,7 @@ class ServiceRestProxy extends RestProxy
      *
      * @param string $primaryUri   The storage account
      *                             primary uri.
-     * @param string $secondaryUri The storage account
+     * @param string|null $secondaryUri The storage account
      *                             secondary uri.
      * @param string $accountName  The name of the account.
      * @param array  $options      Array of options for
@@ -42,14 +42,18 @@ class ServiceRestProxy extends RestProxy
         array $options = []
     ) {
         $primaryUri = Utilities::appendDelimiter($primaryUri, '/');
-        $secondaryUri = Utilities::appendDelimiter($secondaryUri, '/');
+
+        if ($secondaryUri !== null) {
+            $secondaryUri = Utilities::appendDelimiter($secondaryUri, '/');
+            $this->psrSecondaryUri = new Uri($secondaryUri);
+        }
 
         $dataSerializer = new XmlSerializer();
         parent::__construct($dataSerializer);
 
         $this->accountName = $accountName;
         $this->psrPrimaryUri = new Uri($primaryUri);
-        $this->psrSecondaryUri = new Uri($secondaryUri);
+
         $this->options = array_merge(['http' => []], $options);
         $this->client = self::createClient($this->options['http']);
     }


### PR DESCRIPTION
When creating a BlobService from a connection string with sas (see https://github.com/Azure-OSS/azure-storage-php/blob/0663c8e7e0eaac9c1f9851de69a9d3073ce09cc5/samples/BlobSamples.php#L409), it fails because there the secondary uri will not be set and it fails in ServiceRestProxy.

I'm pretty new to azure and to this library, but I guess there are times, when the secondary uri might be null? My first shot is just to not set secondaryUri, which works for our use case. What do you think?
